### PR TITLE
rpsc3: infer container

### DIFF
--- a/Casks/rpcs3.rb
+++ b/Casks/rpcs3.rb
@@ -17,7 +17,6 @@ cask "rpcs3" do
   end
 
   depends_on macos: ">= :monterey"
-  container type: :seven_zip
 
   app "RPCS3.app"
 


### PR DESCRIPTION
Don't explicitly suggest `container`, can be detected automatically.