### PR TITLE
Add zap path CI warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,6 @@ jobs:
           brew ruby <<'EOF'
             require "cask/cask_loader"
             require "open3"
-            require "timeout"
             require "utils/github/actions"
 
             cask = Cask::CaskLoader.load('${{ matrix.cask.path }}')
@@ -264,22 +263,6 @@ jobs:
             end
 
             sleep 10 if app_artifacts.any?
-
-            app_artifacts.each do |artifact|
-              info_plist = artifact.target/"Contents/Info.plist"
-              next unless info_plist.file? && info_plist.readable?
-
-              bundle_id, _, status = Open3.capture3(
-                "/usr/bin/plutil", "-extract", "CFBundleIdentifier", "raw", "-o", "-", info_plist.to_s
-              )
-              next if !status.success? || bundle_id.blank?
-
-              Timeout.timeout(10) do
-                system "/usr/bin/osascript", "-e", "quit app id \"#{bundle_id.strip}\""
-              end
-            rescue Timeout::Error
-              nil
-            end
 
             brew = ENV.fetch("HOMEBREW_BREW_FILE")
             stdout, stderr, status = Open3.capture3(brew, "generate-zap", cask.full_name)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,12 @@ jobs:
 
             cask = Cask::CaskLoader.load('${{ matrix.cask.path }}')
 
+            def append_step_summary(markdown)
+              return unless (summary_path = ENV["GITHUB_STEP_SUMMARY"])
+
+              File.open(summary_path, "a") { |file| file.puts markdown }
+            end
+
             app_artifacts = cask.artifacts.grep(Cask::Artifact::App).select do |artifact|
               artifact.target.directory?
             end
@@ -280,6 +286,15 @@ jobs:
             unless status.success?
               message = "Unable to check generated zap paths:\n#{stderr.presence || stdout}"
               puts GitHub::Actions::Annotation.new(:warning, message, file: '${{ matrix.cask.path }}')
+              append_step_summary <<~MARKDOWN
+                ## Possible missing zap paths
+
+                Unable to check `#{cask.full_name}` with `brew generate-zap`.
+
+                ```text
+                #{stderr.presence || stdout}
+                ```
+              MARKDOWN
               exit
             end
 
@@ -305,6 +320,15 @@ jobs:
             message += missing_paths.join("\n")
             puts GitHub::Actions::Annotation.new(:warning, message, file: '${{ matrix.cask.path }}',
                                                            title: "Possible missing zap paths")
+            append_step_summary <<~MARKDOWN
+              ## Possible missing zap paths
+
+              `brew generate-zap #{cask.full_name}` found paths not covered by the current zap stanza:
+
+              ```text
+              #{missing_paths.join("\n")}
+              ```
+            MARKDOWN
           EOF
         if: >
           always() &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,12 +254,36 @@ jobs:
               File.open(summary_path, "a") { |file| file.puts markdown }
             end
 
+            def system_command_with_timeout(*command, timeout:)
+              pid = Process.spawn(*command, out: File::NULL, err: File::NULL)
+              deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+
+              loop do
+                process_id, status = Process.waitpid2(pid, Process::WNOHANG)
+                return status.success? if process_id
+                break if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+                sleep 0.1
+              end
+
+              Process.kill("TERM", pid)
+              sleep 1
+              Process.kill("KILL", pid)
+              Process.wait(pid)
+              false
+            rescue Errno::ECHILD, Errno::ESRCH
+              false
+            end
+
             app_artifacts = cask.artifacts.grep(Cask::Artifact::App).select do |artifact|
               artifact.target.directory?
             end
 
             app_artifacts.each do |artifact|
-              system "/usr/bin/open", "-g", artifact.target.to_s
+              system_command_with_timeout(
+                "/usr/bin/open", "-g", artifact.target.to_s,
+                timeout: 10,
+              )
             end
 
             sleep 10 if app_artifacts.any?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,82 @@ jobs:
           !matrix.skip_install
         timeout-minutes: 30
 
+      - name: Check for additional zap paths
+        run: |
+          brew ruby <<'EOF'
+            require "cask/cask_loader"
+            require "open3"
+            require "timeout"
+            require "utils/github/actions"
+
+            cask = Cask::CaskLoader.load('${{ matrix.cask.path }}')
+
+            app_artifacts = cask.artifacts.grep(Cask::Artifact::App).select do |artifact|
+              artifact.target.directory?
+            end
+
+            app_artifacts.each do |artifact|
+              system "/usr/bin/open", "-g", artifact.target.to_s
+            end
+
+            sleep 10 if app_artifacts.any?
+
+            app_artifacts.each do |artifact|
+              info_plist = artifact.target/"Contents/Info.plist"
+              next unless info_plist.file? && info_plist.readable?
+
+              bundle_id, _, status = Open3.capture3(
+                "/usr/bin/plutil", "-extract", "CFBundleIdentifier", "raw", "-o", "-", info_plist.to_s
+              )
+              next if !status.success? || bundle_id.blank?
+
+              Timeout.timeout(10) do
+                system "/usr/bin/osascript", "-e", "quit app id \"#{bundle_id.strip}\""
+              end
+            rescue Timeout::Error
+              nil
+            end
+
+            stdout, stderr, status = Open3.capture3("brew", "generate-zap", cask.full_name)
+            unless status.success?
+              message = "Unable to check generated zap paths:\n#{stderr.presence || stdout}"
+              puts GitHub::Actions::Annotation.new(:warning, message, file: '${{ matrix.cask.path }}')
+              exit
+            end
+
+            stanza = stdout[/^zap .*/m]
+            exit unless stanza
+
+            generated_paths = stanza.scan(/"([^"]+)"/).flatten
+            exit if generated_paths.empty?
+
+            existing_paths = cask.artifacts.grep(Cask::Artifact::Zap).flat_map do |artifact|
+              artifact.directives.slice(:trash, :delete, :rmdir).values.flatten
+            end.map(&:to_s)
+
+            missing_paths = generated_paths.reject do |generated_path|
+              existing_paths.any? do |existing_path|
+                existing_path == generated_path || File.fnmatch?(existing_path, generated_path)
+              end
+            end
+
+            exit if missing_paths.empty?
+
+            message = "brew generate-zap found paths not covered by the current zap stanza:\n"
+            message += missing_paths.join("\n")
+            puts GitHub::Actions::Annotation.new(:warning, message, file: '${{ matrix.cask.path }}',
+                                                           title: "Possible missing zap paths")
+          EOF
+        if: >
+          always() &&
+          steps.install.outcome == 'success' &&
+          runner.os == 'macOS' &&
+          (
+            contains(matrix.audit_args, '--new') ||
+            (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'check zap'))
+          )
+        timeout-minutes: 5
+
       - name: Run brew uninstall --cask ${{ matrix.cask.token }}
         run: brew uninstall --cask '${{ matrix.cask.path }}'
         if: always() && steps.install.outcome == 'success' && !fromJSON(steps.info.outputs.manual_installer)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,8 @@ jobs:
               nil
             end
 
-            stdout, stderr, status = Open3.capture3("brew", "generate-zap", cask.full_name)
+            brew = ENV.fetch("HOMEBREW_BREW_FILE")
+            stdout, stderr, status = Open3.capture3(brew, "generate-zap", cask.full_name)
             unless status.success?
               message = "Unable to check generated zap paths:\n#{stderr.presence || stdout}"
               puts GitHub::Actions::Annotation.new(:warning, message, file: '${{ matrix.cask.path }}')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,8 @@ jobs:
 
             cask = Cask::CaskLoader.load('${{ matrix.cask.path }}')
 
+            CommandResult = Struct.new(:success, :timed_out, :exit_status, keyword_init: true)
+
             def append_step_summary(markdown)
               return unless (summary_path = ENV["GITHUB_STEP_SUMMARY"])
 
@@ -260,7 +262,13 @@ jobs:
 
               loop do
                 process_id, status = Process.waitpid2(pid, Process::WNOHANG)
-                return status.success? if process_id
+                if process_id
+                  return CommandResult.new(
+                    success: status.success?,
+                    timed_out: false,
+                    exit_status: status.exitstatus,
+                  )
+                end
                 break if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
 
                 sleep 0.1
@@ -270,9 +278,9 @@ jobs:
               sleep 1
               Process.kill("KILL", pid)
               Process.wait(pid)
-              false
+              CommandResult.new(success: false, timed_out: true, exit_status: nil)
             rescue Errno::ECHILD, Errno::ESRCH
-              false
+              CommandResult.new(success: false, timed_out: false, exit_status: nil)
             end
 
             app_artifacts = cask.artifacts.grep(Cask::Artifact::App).select do |artifact|
@@ -280,10 +288,17 @@ jobs:
             end
 
             app_artifacts.each do |artifact|
-              system_command_with_timeout(
+              result = system_command_with_timeout(
                 "/usr/bin/open", "-g", artifact.target.to_s,
                 timeout: 10,
               )
+
+              if result.timed_out
+                puts "Warning: Timed out opening #{artifact.target} after 10 seconds."
+              elsif !result.success
+                puts "Warning: Failed to open #{artifact.target} " \
+                     "(exit status: #{result.exit_status || "unknown"})."
+              end
             end
 
             sleep 10 if app_artifacts.any?

--- a/Casks/decimator-ucp.rb
+++ b/Casks/decimator-ucp.rb
@@ -17,6 +17,7 @@ cask "decimator-ucp" do
 
   depends_on macos: :big_sur
 
+  # test
   app "UCP #{version} #{arch}.app", target: "Decimator UCP.app"
 
   # No zap stanza required

--- a/Casks/qik.rb
+++ b/Casks/qik.rb
@@ -1,4 +1,5 @@
 cask "qik" do
+  # test
   version "1.2.1"
   sha256 "b13717d46ca2fbfc862f65fa80fa59c09eaa1142b1bc6ff97822724e93f2daac"
 

--- a/Casks/whatsapp.rb
+++ b/Casks/whatsapp.rb
@@ -1,0 +1,32 @@
+cask "whatsapp" do
+  version "26.26.19"
+  sha256 "ac44113b973eca98f8fd54072d53e132144d8e54e5fc1c9699379f6c2c7fa7b7"
+
+  url "https://web.whatsapp.com/desktop/mac_native/release/?version=2.#{version}&extension=zip&configuration=Release&branch=master&is_buck=true"
+  name "WhatsApp"
+  desc "Native desktop client for WhatsApp"
+  homepage "https://www.whatsapp.com/"
+
+  livecheck do
+    url "https://web.whatsapp.com/desktop/mac_native/updates/?branch=master&configuration=Release"
+    strategy :sparkle, &:short_version
+  end
+
+  auto_updates true
+  conflicts_with cask: "whatsapp@beta"
+  depends_on macos: :monterey
+
+  # test
+  app "WhatsApp.app"
+
+  uninstall quit: "net.whatsapp.WhatsApp"
+
+  zap trash: [
+    "~/Library/Application Scripts/net.whatsapp.WhatsApp*",
+    "~/Library/Caches/net.whatsapp.WhatsApp",
+    "~/Library/Containers/net.whatsapp.WhatsApp*",
+    "~/Library/Group Containers/group.com.facebook.family",
+    "~/Library/Group Containers/group.net.whatsapp*",
+    "~/Library/Saved Application State/net.whatsapp.WhatsApp.savedState",
+  ]
+end


### PR DESCRIPTION
Adds a macOS-only CI warning step that launches installed app artifacts, runs `brew generate-zap`, and annotates possible missing zap paths.

The check only runs for new casks or PRs labelled `check zap`.

Validated with `actionlint`, YAML parsing, embedded Ruby syntax compilation, and `git diff --check`.
