### PR TITLE
sharedown: update checksums

### DIFF
--- a/Casks/sharedown.rb
+++ b/Casks/sharedown.rb
@@ -2,8 +2,8 @@ cask "sharedown" do
   arch arm: "-arm64"
 
   version "5.3.6"
-  sha256 arm:   "1418cf8106ade2ba7843add57fe3223f92864949da0f04e7adcdf95547c29ccf",
-         intel: "2248d955046f53676e1ad0a4035305bf4e4ec67fdb918ab6d7c925c4574584e4"
+  sha256 arm:   "13481b1ac40a65555367d2cba60e0021b4a1326c698ac5238a1cabd2c0176472",
+         intel: "253945c40c64321806ac5fcfeaa210b36c1336af3353d6cca75da99becc1fc0f"
 
   url "https://github.com/kylon/Sharedown/releases/download/rolling/sharedown-#{version}#{arch}-mac.7z"
   name "Sharedown"


### PR DESCRIPTION
`sharedown` was failing checksum verification.

The version is unchanged at 5.3.6, but upstream publishes the macOS builds under a
`rolling` release tag and re-uploaded both assets in place (both now dated
2026-02-22), so the recorded checksums no longer match the bytes being served.

Re-hashed both architectures from the current assets:

| Arch  | sha256 |
| ----- | ------ |
| arm   | `13481b1ac40a65555367d2cba60e0021b4a1326c698ac5238a1cabd2c0176472` |
| intel | `253945c40c64321806ac5fcfeaa210b36c1336af3353d6cca75da99becc1fc0f` |

Both downloads were verified as intact 7z archives before hashing.

- `brew style bevanjkay/tap/sharedown` — no offenses
- `brew fetch --cask bevanjkay/tap/sharedown` — verifies clean
