### PR TITLE
mole-static: drop TMPDIR installer workaround

### DIFF
--- a/Casks/mole-static.rb
+++ b/Casks/mole-static.rb
@@ -15,18 +15,9 @@ cask "mole-static" do
 
   depends_on :macos
 
-  # install.sh cleans up with safe_rm, which gates on TMPDIR, but `mktemp -d`
-  # ignores TMPDIR on macOS and brew filters it out of the environment. Without
-  # a matching TMPDIR the cleanup refuses the path and the script exits 1 after
-  # an otherwise successful install. Upstream: tw93/mole.
   installer script: {
-    executable: "/bin/bash",
-    args:       [
-      "-c",
-      "TMPDIR=\"$(getconf DARWIN_USER_TEMP_DIR)\" exec /bin/bash \"$0\" --prefix \"$1\"",
-      "#{staged_path}/install.sh",
-      staged_path.to_s,
-    ],
+    executable: "#{staged_path}/install.sh",
+    args:       ["--prefix", staged_path.to_s],
   }
   binary "mo"
   binary "mole"


### PR DESCRIPTION
## Summary

Removes the `TMPDIR` wrapper added while working around an upstream bug in mole 1.49.1. Fixed upstream in V1.49.2 via [tw93/Mole#1347](https://github.com/tw93/Mole/pull/1347), so the cask can go back to invoking `install.sh` directly.

Both halves of the original failure are fixed in the V1.49.2 tag (confirmed against the tag, not just `main`):

- `fetch_source` now passes an explicit template — `mktemp -d "${TMPDIR:-/tmp}/mole.XXXXXX"` — so it honours `TMPDIR` instead of silently landing in the Darwin per-user temp dir.
- `cleanup_installer` now calls `safe_rm ... || true`, so teardown can no longer turn a finished install into a non-zero exit.

## Verification

Ran the V1.49.2 `install.sh` directly, unprivileged, with `TMPDIR` unset and no wrapper, against a prefix with Caskroom permissions:

```
◎ Mole installed successfully, version 1.49.2
EXIT: 0
```

No `safe_rm` refusal.

## Note

`sudo` stays off. That was a separate fix and is still required — the unsafe-ancestor check is still present in V1.49.2, and it rejects the group-writable `Caskroom` prefix when the installer runs privileged.
