### PR TITLE
jq-static, squirrelscan: order sha256 arch keys

### DIFF
--- a/Casks/jq-static.rb
+++ b/Casks/jq-static.rb
@@ -5,8 +5,8 @@ cask "jq-static" do
   version "1.8.2"
   sha256 arm:          "2d75340ba57a4b4b4c8708a21c2dc8e958a48aaa8bba13b27f77f6e4c0eca07e",
          intel:        "e94b266e3c26690550006abe63152b782280f4e14374accdf04cbde844f00bc0",
-         x86_64_linux: "b1c22172dd303f3be49e935aa56aa48a8b7a46e0bc838b4997d3bb451495870f",
-         arm64_linux:  "8b85c817833814ddca00a144c33705546355afccf0cf39b188f3cdb48b852309"
+         arm64_linux:  "8b85c817833814ddca00a144c33705546355afccf0cf39b188f3cdb48b852309",
+         x86_64_linux: "b1c22172dd303f3be49e935aa56aa48a8b7a46e0bc838b4997d3bb451495870f"
 
   on_intel do
     postflight do

--- a/Casks/squirrelscan.rb
+++ b/Casks/squirrelscan.rb
@@ -5,8 +5,8 @@ cask "squirrelscan" do
   version "0.0.85"
   sha256 arm:          "bb7fd5488d0a2d72050c390154abefd8e6ff1006601bd809f52bae96670e3f28",
          intel:        "d5bd9ca82090dfb822075550f4af79097c26e9f29e63ef60b88cab6862d412d6",
-         x86_64_linux: "7767c89fbe594890a6b6ca06d44fec6de765dd0c585c2d7fa2684c69daf5b76f",
-         arm64_linux:  "15a534140a8f14ee1a8f83cc55ae623b0ae4038f1ebe899e3759490dc8e2941a"
+         arm64_linux:  "15a534140a8f14ee1a8f83cc55ae623b0ae4038f1ebe899e3759490dc8e2941a",
+         x86_64_linux: "7767c89fbe594890a6b6ca06d44fec6de765dd0c585c2d7fa2684c69daf5b76f"
 
   url "https://github.com/squirrelscan/squirrelscan/releases/download/v#{version}/squirrel-#{version}-#{os}-#{arch}",
       verified: "github.com/squirrelscan/squirrelscan/"


### PR DESCRIPTION
## Summary

Fixes `tap_syntax` failing on every PR against this tap, including the open `brew bump` PRs.

`Cask/Sha256ArchOrder` requires `sha256` architecture keys in the order `arm, intel (or x86_64), arm64_linux, x86_64_linux`. Both `jq-static` and `squirrelscan` had the two Linux keys reversed:

```
-         x86_64_linux: "...",
-         arm64_linux:  "..."
+         arm64_linux:  "...",
+         x86_64_linux: "..."
```

Each hash moved with its key, so no checksum is reassigned.

## Why now

The cop is newer than the Homebrew these casks were last styled against — it isn't present in Homebrew 6.0.16 locally, but CI runs a version that has it. Because `brew style` runs across the whole tap, these two pre-existing offenses fail `tap_syntax` on unrelated PRs.

Seen on #3316 (`mole-static 1.51.0`), where both install tests passed and only `tap_syntax` failed:

```
Taps/bevanjkay/homebrew-tap/Casks/jq-static.rb:6:3: C: [Correctable] Cask/Sha256ArchOrder
Taps/bevanjkay/homebrew-tap/Casks/squirrelscan.rb:6:3: C: [Correctable] Cask/Sha256ArchOrder
75 files inspected, 2 offenses detected, 2 offenses autocorrectable
```

## Verification

`brew style bevanjkay/tap` is clean and both casks parse. Local Homebrew lacks the cop, so CI on this PR is the real check.
