### PR TITLE
bmd-fairlight-live 1.0.0 (new cask)

### DIFF
--- a/Casks/bmd-fairlight-live.rb
+++ b/Casks/bmd-fairlight-live.rb
@@ -1,0 +1,85 @@
+cask "bmd-fairlight-live" do
+  require "#{HOMEBREW_TAP_DIRECTORY}/bevanjkay/homebrew-tap/cmd/lib/bmd_download_strategy"
+
+  version "1.0.0,4237d6c19ca7428a9db488ae3af2a2f8,fb404479a42540a8b9767e27f32472ec"
+  sha256 "5cd9c45d63f685433bb5693df1dee8685f9062eae3b175f5b5591d6f22090514"
+
+  personal_details = if File.exist?("#{Dir.home}/.personal_details.json")
+    JSON.parse(File.read("#{Dir.home}/.personal_details.json"))
+  else
+    {
+      "firstname"   => "Joe",
+      "lastname"    => "Bloggs",
+      "email"       => "email@example.com",
+      "phone"       => "61412345678",
+      "address"     => "123 Main Street",
+      "city"        => "Melbourne",
+      "state"       => "Victoria",
+      "zip"         => "3000",
+      "countrycode" => "au",
+    }
+  end
+
+  params = {
+    "platform"         => "Mac OS X",
+    "product"          => "Fairlight Live",
+    "firstname"        => personal_details["firstname"],
+    "lastname"         => personal_details["lastname"],
+    "email"            => personal_details["email"],
+    "phone"            => personal_details["phone"],
+    "street"           => personal_details["address"],
+    "city"             => personal_details["city"],
+    "state"            => personal_details["state"],
+    "zip"              => personal_details["zip"],
+    "country"          => personal_details["countrycode"],
+    "policy"           => true,
+    "hasAgreedToTerms" => true,
+  }
+
+  url "https://www.blackmagicdesign.com/api/register/us/download/#{version.csv.third}",
+      using: BmdDownloadStrategy,
+      data:  params
+  name "Fairlight Live"
+  name "Blackmagic Fairlight Live"
+  desc "Audio mixer for broadcast and live events"
+  homepage "https://www.blackmagicdesign.com/au/products/fairlightlive/"
+
+  livecheck do
+    url "https://www.blackmagicdesign.com/api/support/us/downloads.json"
+    strategy :json do |json|
+      matched = json["downloads"].select do |download|
+        next false if /beta/i.match?(download["name"])
+        next false if download["urls"]["Mac OS X"].blank?
+
+        download["urls"]["Mac OS X"].first["product"] == "fairlight-live"
+      end
+      matched.map do |download|
+        v = download["urls"]["Mac OS X"].first
+        "#{v["major"]}.#{v["minor"]}.#{v["releaseNum"]},#{v["releaseId"]},#{v["downloadId"]}"
+      end
+    end
+  end
+
+  # Doesn't automatically update, but set to true to prevent `brew upgrade` from forcing an update
+  auto_updates true
+  depends_on macos: :sonoma
+
+  # The installer filename embeds the internal package version, not just the release version
+  pkg "Install Fairlight Live #{version.csv.first}release_fairlight_live_#{version.csv.first.chomp(".0")}.pkg"
+
+  uninstall script:  {
+              executable: "/Applications/Fairlight Live/Uninstall Fairlight Live.app/Contents/Resources/uninstall_fairlightlive.sh",
+              sudo:       true,
+            },
+            pkgutil: [
+              "com.blackmagic-design.FairlightLive",
+              "com.blackmagic-design.ManifestFairlightLive",
+              "com.blackmagic-design.ManifestPanelsFairlightLive",
+            ]
+
+  zap trash: [
+    "~/Library/Application Support/Blackmagic Design/Fairlight Live",
+    "~/Library/Preferences/Blackmagic Design/Fairlight Live",
+    "~/Library/Saved Application State/com.blackmagic-design.BlackmagicFairlightLive.savedState",
+  ]
+end


### PR DESCRIPTION
New cask for Blackmagic Design Fairlight Live 1.0, modelled on the `davinci-resolve` cask since the download requires registration (`downloadOnly` is rejected with "Must register to be able to perform the download").

Everything below was verified against the actual 1.0 download:

- `sha256` from `Fairlight_Live_1.0_Mac.zip` (zip contains `Fairlight_Live_1.0_Mac.dmg`).
- `pkg` filename embeds the internal package version (`Install Fairlight Live 1.0.0release_fairlight_live_1.0.pkg`), so it's built from `version.csv.first` plus the `release_fairlight_live_<x.y>` suffix. `brew info` resolves it to the exact filename on the disk image.
- `depends_on macos: :sonoma` — the installer's `pm_install_check` requires macOS 14.5 or later.
- `pkgutil` receipts: `ManifestFairlightLive` and `ManifestPanelsFairlightLive` come from the outer distribution; `FairlightLive` comes from the nested `Fairlight Live Panels Installer v1.0.pkg` run by the panels postinstall script.
- `uninstall script` path taken from `Uninstall Fairlight Live.app/Contents/Resources/uninstall_fairlightlive.sh` (only removes `/Applications/Fairlight Live`; the `/Library/Application Support` payload is cleaned up by the `pkgutil` receipts).
- `zap` paths from the postinstall script, plus the app's bundle ID `com.blackmagic-design.BlackmagicFairlightLive`.

Note: this uses `personal_details["zip"]` rather than `personal_details["postcode"]` that `davinci-resolve` and `davinci-resolve-project-server` use — `"zip"` is the key in the fallback hash, so those two look like they're passing `nil`. Happy to fix them separately if you agree.

`brew style`, `brew audit --cask --online` and `brew livecheck` all pass.
