### PR TITLE
font-artifact-updater: require cask/cask_loader explicitly

### DIFF
--- a/cmd/font-artifact-updater.rb
+++ b/cmd/font-artifact-updater.rb
@@ -5,6 +5,7 @@ require "abstract_command"
 require "open3"
 require "digest"
 require "cask/download"
+require "cask/cask_loader"
 
 module Homebrew
   module Cmd


### PR DESCRIPTION
`cmd/font-artifact-updater.rb` calls `Cask::CaskLoader.load` but relied on the constant being loaded transitively. This adds an explicit `require "cask/cask_loader"` alongside the existing `cask/download` require.

Verified with `brew style cmd/font-artifact-updater.rb` (no offenses) and `brew font-artifact-updater --help` (command loads correctly). No other branches touch this file, so the fix only applies to `main`.
